### PR TITLE
Sometimes, a child of a node actually doesn't fit into the parent one…

### DIFF
--- a/gui/Profiler.Data/Durationable.cs
+++ b/gui/Profiler.Data/Durationable.cs
@@ -71,24 +71,26 @@ namespace Profiler.Data
 			return settings.TicksToMs * duration;
 		}
 
+		private const long timeErrorCorrection = 1;
+
 		public bool Intersect(long value)
 		{
-			return Start <= value && value <= Finish;
+			return Start - timeErrorCorrection <= value && value <= Finish + timeErrorCorrection;
 		}
 
 		public bool Intersect(IDurable other)
 		{
-			return Start <= other.Finish && Finish >= other.Start;
+			return Start - timeErrorCorrection <= other.Finish && Finish + timeErrorCorrection >= other.Start;
 		}
 
 		public bool Contains(IDurable other)
 		{
-			return Start <= other.Start && Finish >= other.Finish;
+			return Start - timeErrorCorrection <= other.Start && Finish + timeErrorCorrection >= other.Finish;
 		}
 
 		public bool Within(IDurable other)
 		{
-			return Start >= other.Start && Finish <= other.Finish;
+			return Start + timeErrorCorrection >= other.Start && Finish - timeErrorCorrection <= other.Finish;
 		}
 
 		public double Overlap(Durable entry)


### PR DESCRIPTION
…. This is probably due to measurement errors on the GPU. This results in an exception when clicking on the time graph to jump to a frame, as the node is not found. Could be just null checked, but that would result in clicking on the timeline and jumping to nowhere.

This commit adds a small error correction, so the required node can be found.