### PR TITLE
Fix crash related to clipboard text set

### DIFF
--- a/gui/Profiler.Controls/ThreadView/EventThreadView.xaml.cs
+++ b/gui/Profiler.Controls/ThreadView/EventThreadView.xaml.cs
@@ -613,7 +613,7 @@ namespace Profiler.Controls
 					if (sample.Path != FileLine.Empty)
 						stringCallstack += $"\t{sample.Path.File}({sample.Path.Line})\n";
 				}
-				Clipboard.SetText(stringCallstack);
+				Clipboard.SetDataObject(stringCallstack);
 			}
 		}
 

--- a/gui/daProfiler/Controls/FrameCapture.xaml.cs
+++ b/gui/daProfiler/Controls/FrameCapture.xaml.cs
@@ -419,7 +419,7 @@ namespace Profiler.Controls
 					info += $"Per frame :\t|\t{Data.Utils.ConvertMsToString(stats.AvgTotalPerCall)}\t|\t{Data.Utils.ConvertMsToString(stats.P90PerCall)}\t|\t{Data.Utils.ConvertMsToString(stats.MinPerCall)}\t|\t{Data.Utils.ConvertMsToString(stats.MaxPerCall)}\t|\t{Data.Utils.ConvertMsToString(stats.StdDevPerCall)}\n";
 					stats = FunctionThreadSummaryVM.Stats;
 					info += $"Per thread:\t|\t{Data.Utils.ConvertMsToString(stats.AvgTotalPerCall)}\t|\t{Data.Utils.ConvertMsToString(stats.P90PerCall)}\t|\t{Data.Utils.ConvertMsToString(stats.MinPerCall)}\t|\t{Data.Utils.ConvertMsToString(stats.MaxPerCall)}\t|\t{Data.Utils.ConvertMsToString(stats.StdDevPerCall)}\n";
-					Clipboard.SetText(info);
+					Clipboard.SetDataObject(info);
 				}
 			}
 		}

--- a/gui/daProfiler/Frames/FrameInfo.xaml.cs
+++ b/gui/daProfiler/Frames/FrameInfo.xaml.cs
@@ -317,7 +317,7 @@ namespace Profiler
 		private void TreeViewCopy_Executed(object sender, ExecutedRoutedEventArgs e)
 		{
 			TreeView tree = (TreeView)sender;
-			Clipboard.SetText(tree.SelectedItem.ToString());
+			Clipboard.SetDataObject(tree.SelectedItem.ToString());
 		}
 	}
 

--- a/gui/daProfiler/Properties/AssemblyInfo.cs
+++ b/gui/daProfiler/Properties/AssemblyInfo.cs
@@ -51,5 +51,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.12.0")]
-[assembly: AssemblyFileVersion("1.0.12.0")]
+[assembly: AssemblyVersion("1.0.13.0")]
+[assembly: AssemblyFileVersion("1.0.13.0")]

--- a/gui/daProfiler/Views/UniqueEventsView.xaml.cs
+++ b/gui/daProfiler/Views/UniqueEventsView.xaml.cs
@@ -55,7 +55,7 @@ namespace Profiler.Views
 						info += $"{ue.Description}\t|\t{ue.Calls:00000}\t|\t{ue.Frames:0000}\t|\t{Data.Utils.ConvertMsToString(ue.MinTime)}\t|\t{Data.Utils.ConvertMsToString(ue.MaxTime)}\t|\t{Data.Utils.ConvertMsToString(ue.AvgCall)}\t|\t{Data.Utils.ConvertMsToString(ue.AvgFrame)}\t|\t{Data.Utils.ConvertMsToString(ue.TotalTime)}\n";
 					}
 					if (stats.Count != 0)
-						Clipboard.SetText(info);
+						Clipboard.SetDataObject(info);
 				}
 			}
 		}


### PR DESCRIPTION
Now we use SetDataObject method instead of SetText, because it makes 10 attempts with 100ms delay between them to set the text to the clipboard, while SetText method makes only one attempt and raise an exception if it fails.

Version increased.