### PR TITLE
Add "-ip <device_ip>" command line option

### DIFF
--- a/gui/daProfiler/Properties/AssemblyInfo.cs
+++ b/gui/daProfiler/Properties/AssemblyInfo.cs
@@ -51,5 +51,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.14.0")]
-[assembly: AssemblyFileVersion("1.0.14.0")]
+[assembly: AssemblyVersion("1.0.15.0")]
+[assembly: AssemblyFileVersion("1.0.15.0")]

--- a/gui/daProfiler/ViewModels/AddressBarViewModel.cs
+++ b/gui/daProfiler/ViewModels/AddressBarViewModel.cs
@@ -152,15 +152,14 @@ namespace Profiler.ViewModels
             AddEditableItem();
 
             string[] commandLineArgs = Environment.GetCommandLineArgs();
-            if (commandLineArgs.Length == 3)
+            int ipArgIndex = Array.IndexOf(commandLineArgs, "-ip");
+            int ipValueArgIndex = ipArgIndex + 1;
+            if (ipValueArgIndex > 0 && ipValueArgIndex < commandLineArgs.Length)
             {
-                if (commandLineArgs[1] == "-ip")
-                {
-                    ConnectionVM commandLineConnection = new ConnectionVM() { Name = "command_line", Address = commandLineArgs[2], CanDelete = false };
-                    Connections.Add(commandLineConnection);
-                    Select(commandLineConnection.GetConnection());
-                    return;
-                }
+                ConnectionVM commandLineConnection = new ConnectionVM() { Name = "command_line", Address = commandLineArgs[ipValueArgIndex], CanDelete = false };
+                Connections.Add(commandLineConnection);
+                Select(commandLineConnection.GetConnection());
+                return;
             }
 
             Select(Settings.LocalSettings.Data.LastConnection);

--- a/gui/daProfiler/ViewModels/AddressBarViewModel.cs
+++ b/gui/daProfiler/ViewModels/AddressBarViewModel.cs
@@ -151,6 +151,18 @@ namespace Profiler.ViewModels
 
             AddEditableItem();
 
+            string[] commandLineArgs = Environment.GetCommandLineArgs();
+            if (commandLineArgs.Length == 3)
+            {
+                if (commandLineArgs[1] == "-ip")
+                {
+                    ConnectionVM commandLineConnection = new ConnectionVM() { Name = "command_line", Address = commandLineArgs[2], CanDelete = false };
+                    Connections.Add(commandLineConnection);
+                    Select(commandLineConnection.GetConnection());
+                    return;
+                }
+            }
+
             Select(Settings.LocalSettings.Data.LastConnection);
         }
 


### PR DESCRIPTION
This feature aims to help managing connections to a large amount of profiling targets. If target's ip is known (e.g. via adb), it is easier to launch the profiler with this ip from command line, instead of looking for it in a list or entering manually.

Intended to be used in a script, e.g:
1. get device <ip> with adb;
2. run profiler with -ip <ip>.