### PR TITLE
Fix Sampling in Settings

### DIFF
--- a/gui/Profiler.Data/CaptureSettings.cs
+++ b/gui/Profiler.Data/CaptureSettings.cs
@@ -9,7 +9,7 @@ namespace Profiler.Data
 {
     public class CaptureSettings
     {
-		public Mode	Mode { get; set; } = (Mode.EVENTS | Mode.TAGS | Mode.SAMPLING);
+		public Mode	Mode { get; set; } = Mode.OFF;
 		public UInt32 SamplingFrequencyHz { get; set; } = 100;
 		public UInt32 SpikeSamplingFrequencyHz { get; set; } = 1000;
 		public UInt32 ThreadsSamplingRate { get; set; } = 2;

--- a/gui/daProfiler/Properties/AssemblyInfo.cs
+++ b/gui/daProfiler/Properties/AssemblyInfo.cs
@@ -51,5 +51,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.15.0")]
-[assembly: AssemblyFileVersion("1.0.15.0")]
+[assembly: AssemblyVersion("1.0.16.0")]
+[assembly: AssemblyFileVersion("1.0.16.0")]

--- a/gui/daProfiler/ViewModels/CaptureSettingsViewModel.cs
+++ b/gui/daProfiler/ViewModels/CaptureSettingsViewModel.cs
@@ -254,6 +254,8 @@ namespace Profiler.ViewModels
 		{
 			CaptureSettings settings = new CaptureSettings();
 
+			settings.Mode = Mode.OFF;
+
 			foreach (Flag flag in FlagSettings)
 				if (flag.IsEnabled)
 					settings.Mode = settings.Mode | flag.Mask;

--- a/gui/daProfiler/ViewModels/CaptureSettingsViewModel.cs
+++ b/gui/daProfiler/ViewModels/CaptureSettingsViewModel.cs
@@ -254,8 +254,6 @@ namespace Profiler.ViewModels
 		{
 			CaptureSettings settings = new CaptureSettings();
 
-			settings.Mode = Mode.OFF;
-
 			foreach (Flag flag in FlagSettings)
 				if (flag.IsEnabled)
 					settings.Mode = settings.Mode | flag.Mask;


### PR DESCRIPTION
Sampling was always enabled and can't be unset.
On Android devices sampling might crash the app.
So, we need to be able to connect to the device with disabled sampling.