### PR TITLE
Fix VLQ-int decoding mismatch that crashed DAP load on threads >= 64

### DIFF
--- a/gui/Profiler.Data/Utils.cs
+++ b/gui/Profiler.Data/Utils.cs
@@ -208,7 +208,7 @@ namespace Profiler.Data
             // first continue flag is the second bit from the top, shift it into the sign
             bool cont = (b & 0x80) != 0;
 
-			for (int shift = 7; shift < 32 && cont; shift += 7)
+			for (int shift = 6; shift < 32 && cont; shift += 7)
 			{
 				b = r.ReadByte();
 				cont = (b & 0x80) != 0;

--- a/gui/daProfiler/Properties/AssemblyInfo.cs
+++ b/gui/daProfiler/Properties/AssemblyInfo.cs
@@ -51,5 +51,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.16.0")]
-[assembly: AssemblyFileVersion("1.0.16.0")]
+[assembly: AssemblyVersion("1.0.17.0")]
+[assembly: AssemblyFileVersion("1.0.17.0")]


### PR DESCRIPTION
Profiler.Data.Utils.ReadVlqInt started the continuation-byte shift at 7 bits instead of 6. The recorder's write_vlq_int stores 6 value bits + sign
+ continue in byte 1, then shifts the remaining value right by 6 -- so byte 2 carries value bits 6..12. Decoding it at shift 7 silently dropped value bit 6, making every signed VLQ >= 64 read back as `value + 64`.

Thread indices encode through this path. A capture with 72 threads wrote indices 0..71, but the viewer decoded the high end as 128..135, sending AddFrame past the end of Board.Threads and throwing ArgumentOutOfRangeException in FrameCollection.cs.

Fix: start the shift at 6 so byte 2 contributes bits 6..12, matching the writer. ReadVlqUInt is unaffected (writer and reader both use 7-bit chunks there).